### PR TITLE
Groupes et séparation du prefixe

### DIFF
--- a/src/managers/CommandManager.js
+++ b/src/managers/CommandManager.js
@@ -4,11 +4,12 @@ const Command = require('../structures/Command');
 
 class CommandManager {
 
-    constructor() {
+    constructor(prefix = true) {
         this.cache = {
             commands: new Map(),
             aliases: new Map()
-        }
+        };
+        this.prefix = prefix;
     }
 
     /**
@@ -17,20 +18,29 @@ class CommandManager {
      */
     load(client, json) {
 
-        const { prefix } = client.options;
+        //const { prefix } = client.options;
 
         for (let [ name, values ] of Object.entries(json)) {
+            let cmd;
 
-            const cmd = new Command(client, name, values);
+            if (values.commands) {
+                let Group = require('../structures/Group'); // Not at the top bcs it causes a circular dependency.
+                cmd = new Group(client, this.prefix, name, values);
+            }
+            else {
+                cmd = new Command(client, this.prefix, name, values);
+            }
+
+
             if (cmd.isAvailable()) {
 
-                name = cmd.prefix ? prefix + name : name;
+                //name = cmd.prefix ? prefix + name : name;
 
                 this.cache.commands.set(name, cmd);
 
                 for (let alias of cmd.aliases) {
-                    alias = cmd.prefix ? prefix + alias : alias;
-                    this.cache.aliases.set(alias, name);
+                    //alias = cmd.prefix ? prefix + alias : alias;
+                    this.cache.aliases.set(alias, cmd);
                 }
 
             }

--- a/src/structures/Command.js
+++ b/src/structures/Command.js
@@ -5,14 +5,14 @@ const Util = require('../util/Util');
 
 class Command {
 
-    constructor(client, name, values = {}) {
+    constructor(client, prefixDefault, name, values = {}) {
       
         this.client = client;
         this.name = name;
 
         const { prefix, unique, aliases, script } = values;
 
-        this.prefix = prefix !== undefined ? prefix : true;
+        this.prefix = prefix !== undefined ? prefix : prefixDefault;
 
         this.unique = unique !== undefined ? unique : false;
 

--- a/src/structures/Group.js
+++ b/src/structures/Group.js
@@ -7,8 +7,9 @@ class Group extends Command {
     constructor(client, prefix, name, values = {}) {
         super(client, prefix, name, values);
 
-        this.manager = new CommandManager(false);
-        this.manager.load(client, values.commands);
+        this.managers = [];
+        this.managers['command'] = new CommandManager(false);
+        this.managers['command'].load(client, values.commands);
     }
 }
 

--- a/src/structures/Group.js
+++ b/src/structures/Group.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Command = require('./Command');
+const CommandManager = require('../managers/CommandManager');
+
+class Group extends Command {
+    constructor(client, prefix, name, values = {}) {
+        super(client, prefix, name, values);
+
+        this.manager = new CommandManager(false);
+        this.manager.load(client, values.commands);
+    }
+}
+
+module.exports = Group;

--- a/test/cmdtest.yml
+++ b/test/cmdtest.yml
@@ -59,3 +59,17 @@ osu:
         roles:
             # role name
             - osu
+
+# A group is basically a command that holds other commands
+groupe:
+    commands:
+        echo:
+            script: 'echo'
+            options:
+                delete: 1500
+    # A script can be executed if no command fits the 2nd word
+    script: 'message'
+    options:
+        message:
+            content:
+                - 'Fait groupe echo <mot>'

--- a/test/scripts/help.js
+++ b/test/scripts/help.js
@@ -1,0 +1,44 @@
+const Command = require('../../src/structures/Command');
+const Discord = require('discord.js');
+
+module.exports = (options, message) => {
+    let bot = message.client; // all those should be script_options, TODO
+    let prefix = bot.options.prefix;
+    let title = "Commands";
+    let description = `**Prefix:** ${prefix}`;
+    let color = 0;
+    let thumbnailUrl = bot.user.avatarURL();
+    let fields = [];
+    let maxLength = 60;
+
+    let commandHolder = bot; //abstraction to allow Groups later on
+    let target;
+    let counter = 2;
+    let goOn = true;
+    while (counter < arguments.length && goOn) {
+        goOn = false;
+        for (let command of commandHolder.managers.command.cache.commands) {
+            if (command.name === arguments[counter]) {
+                target = command;
+                break;
+            }
+        }
+        counter += 1;
+    }
+    if (!target)
+        target = commandHolder;
+    if (target instanceof Command) {
+        let field = { "name": `**${target.name} *${target.usage}* **`, "value": `${target.description}` };
+        fields.push(field);
+    }
+    else {
+        for (let command of target.managers.command.cache.commands) {
+            let field = { "name": `**${command.name}**`, "value": `${truncateStr(command.description, maxLength)}` };
+            fields.push(field);
+        }
+    }
+    let embed = new Discord.MessageEmbed({ "title": title, "description": description, "color": color, "fields": fields });
+    if (thumbnailUrl)
+        embed.setThumbnail(thumbnailUrl);
+    message.channel.send(embed);
+};


### PR DESCRIPTION
message.js : le prefixe est vérifié avant de chercher la commande, commandHandler s'occupe de chercher la commande et vérifier si le prefixe est nécessaire.
CommandManager.js && Command.js : La valeur prefix = true ne marche plus lorsqu'on est dans un Group, alors maintenant c'est une variable du constructor.
Group.js : Une commande qui peut contenir d'autres commandes, donc qui contient un CommandManager.
cmdtest.yml : Test des groupes
help.js : WIP